### PR TITLE
Share Rubocop config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# IntelliJ IDEA files
+.idea

--- a/.rubocop_fairmoney.yml
+++ b/.rubocop_fairmoney.yml
@@ -1,0 +1,2 @@
+require:
+  - ./lib/rubocop-fairmoney.rb

--- a/.rubocop_fairmoney.yml
+++ b/.rubocop_fairmoney.yml
@@ -1,2 +1,7 @@
 require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rake
+  - rubocop-rspec
+  - rubocop-thread_safety
   - ./lib/rubocop-fairmoney.rb

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ gemspec
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.13"
+gem "rubocop-performance", require: false
+gem "rubocop-rails", require: false
+gem "rubocop-rake", require: false
+gem "rubocop-rspec", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
+gem "rubocop-thread_safety", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
+gem "rubocop", "~> 0.90"

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
-gem "rubocop", "~> 0.90"
+gem "rubocop", "~> 1.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,8 @@ PLATFORMS
 DEPENDENCIES
   rake (~> 12.0)
   rspec (~> 3.0)
+  rubocop (~> 0.90)
   rubocop-fairmoney!
 
 BUNDLED WITH
-   2.1.2
+   2.2.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       rubocop-rails
       rubocop-rake
       rubocop-rspec
+      rubocop-thread_safety
 
 GEM
   remote: https://rubygems.org/
@@ -67,6 +68,8 @@ GEM
     rubocop-rspec (2.2.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
+    rubocop-thread_safety (0.4.2)
+      rubocop (>= 0.53.0)
     ruby-progressbar (1.11.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -85,6 +88,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rake
   rubocop-rspec
+  rubocop-thread_safety
 
 BUNDLED WITH
    2.2.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,15 +7,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.1)
+    ast (2.4.2)
     diff-lcs (1.4.4)
-    parallel (1.19.2)
-    parser (2.7.1.4)
+    parallel (1.20.1)
+    parser (3.0.1.0)
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (12.3.3)
-    regexp_parser (1.7.1)
-    rexml (3.2.4)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -29,19 +29,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.90.0)
+    rubocop (1.13.0)
       parallel (~> 1.10)
-      parser (>= 2.7.1.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.3.0, < 1.0)
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.3.0)
-      parser (>= 2.7.1.4)
-    ruby-progressbar (1.10.1)
-    unicode-display_width (1.7.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
@@ -49,7 +49,7 @@ PLATFORMS
 DEPENDENCIES
   rake (~> 12.0)
   rspec (~> 3.0)
-  rubocop (~> 0.90)
+  rubocop (~> 1.13)
   rubocop-fairmoney!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-fairmoney (0.1.0)
+    rubocop-fairmoney (0.2.0)
       rubocop
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,15 +3,30 @@ PATH
   specs:
     rubocop-fairmoney (0.2.0)
       rubocop
+      rubocop-performance
+      rubocop-rails
+      rubocop-rake
+      rubocop-rspec
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.1.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     ast (2.4.2)
+    concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
+    i18n (1.8.9)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.4)
     parallel (1.20.1)
     parser (3.0.1.0)
       ast (~> 2.4.1)
+    rack (2.2.3)
     rainbow (3.0.0)
     rake (12.3.3)
     regexp_parser (2.1.1)
@@ -40,8 +55,23 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    rubocop-performance (1.10.1)
+      rubocop (>= 0.90.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.9.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.90.0, < 2.0)
+    rubocop-rake (0.5.1)
+      rubocop
+    rubocop-rspec (2.2.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -51,6 +81,10 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 1.13)
   rubocop-fairmoney!
+  rubocop-performance
+  rubocop-rails
+  rubocop-rake
+  rubocop-rspec
 
 BUNDLED WITH
    2.2.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-fairmoney (0.2.0)
+    rubocop-fairmoney (1.0.0)
       rubocop
       rubocop-performance
       rubocop-rails

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,120 @@
 # Write it!
 
+AllCops:
+  EnabledByDefault: true
+  Exclude:
+    - 'bin/**/*'
+    - 'db/schema.rb'
+    - 'vendor/**/*'
+
+Bundler/OrderedGems:
+  TreatCommentsAsGroupSeparators: false
+
 Fairmoney/NoIfInTestDescriptions:
   Description: 'Test descriptions should not include "if", use "when" instead'
   Enabled: true
   VersionAdded: '0.91'
+
+Layout/CaseIndentation:
+  EnforcedStyle: end
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+
+Layout/LineLength:
+  Max: 149
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+  IndentationWidth: 2
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Metrics/BlockLength:
+  Exclude:
+    - 'config/environments/*.rb'
+    - 'config/routes.rb'
+    - 'db/migrate/*'
+    - 'spec/**/*'
+
+Lint/ConstantResolution:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 100
+
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
+
+RSpec/DescribedClass:
+  EnforcedStyle: explicit
+
+RSpec/ExampleLength:
+  Max: 100
+
+RSpec/MessageExpectation:
+  Enabled: false
+
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+
+RSpec/MultipleExpectations:
+  Max: 30
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact
+  Exclude:
+    - 'config/application.rb'
+
+Style/Copyright:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DocumentationMethod:
+  Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  Exclude:
+    - 'db/migrate/*'
+  IgnoredMethods:
+    - gem
+    - ruby
+    - require
+    - require_relative
+    - source
+    - run
+    - load_defaults
+    - raise
+    - throw
+    - render
+    - redirect_to
+    - head
+    - layout
+    - yield
+    - define
+    - describe
+    - to
+    - to_not
+    - not_to
+    - and_return
+    - puts
+    - get
+    - put
+    - post
+
+Style/MissingElse:
+  Enabled: false
+
+Style/StringHashKeys:
+  Exclude:
+    - 'config/routes.rb'

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,3 @@
-# Write it!
-
 AllCops:
   EnabledByDefault: true
   Exclude:
@@ -35,14 +33,10 @@ Metrics/BlockLength:
   Exclude:
     - 'config/environments/*.rb'
     - 'config/routes.rb'
-    - 'db/migrate/*'
-    - 'spec/**/*'
-
-Lint/ConstantResolution:
-  Enabled: false
-
-Metrics/MethodLength:
-  Max: 100
+    - 'db/migrate/*_init_schema.rb'
+  ExcludedMethods:
+    - 'describe'
+    - 'context'
 
 Naming/VariableNumber:
   EnforcedStyle: snake_case
@@ -50,17 +44,11 @@ Naming/VariableNumber:
 RSpec/DescribedClass:
   EnforcedStyle: explicit
 
-RSpec/ExampleLength:
-  Max: 100
-
 RSpec/MessageExpectation:
   Enabled: false
 
 RSpec/MessageSpies:
   EnforcedStyle: receive
-
-RSpec/MultipleExpectations:
-  Max: 30
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact

--- a/lib/rubocop/fairmoney/version.rb
+++ b/lib/rubocop/fairmoney/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Fairmoney
-    VERSION = "0.2.0"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/rubocop/fairmoney/version.rb
+++ b/lib/rubocop/fairmoney/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Fairmoney
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/rubocop-fairmoney.gemspec
+++ b/rubocop-fairmoney.gemspec
@@ -31,5 +31,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'rubocop'
+  spec.add_runtime_dependency 'rubocop-performance'
+  spec.add_runtime_dependency 'rubocop-rails'
+  spec.add_runtime_dependency 'rubocop-rake'
+  spec.add_runtime_dependency 'rubocop-rspec'
 end
 

--- a/rubocop-fairmoney.gemspec
+++ b/rubocop-fairmoney.gemspec
@@ -35,5 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop-rails'
   spec.add_runtime_dependency 'rubocop-rake'
   spec.add_runtime_dependency 'rubocop-rspec'
+  spec.add_runtime_dependency 'rubocop-thread_safety'
 end
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,0 +1,3 @@
+inherit_from:
+  - .rubocop_fairmoney.yml
+  - ./config/default.yml


### PR DESCRIPTION
A generic config can be imported with
```ruby
inherit_gem:
   rubocop-fairmoney: rubocop.yml
```
in each project's .rubocop.yml

Tested on card banking https://github.com/fairmoney/card-banking/pull/63. Overriding rules works as well