### PR TITLE
Remove obsolete parameter warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-fairmoney (1.0.0)
+    rubocop-fairmoney (1.0.1)
       rubocop
       rubocop-performance
       rubocop-rails

--- a/config/default.yml
+++ b/config/default.yml
@@ -34,7 +34,7 @@ Metrics/BlockLength:
     - 'config/environments/*.rb'
     - 'config/routes.rb'
     - 'db/migrate/*_init_schema.rb'
-  ExcludedMethods:
+  IgnoredMethods:
     - 'describe'
     - 'context'
 

--- a/lib/rubocop/fairmoney/version.rb
+++ b/lib/rubocop/fairmoney/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Fairmoney
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
This warning appeared after upgrading Rubocop from 0.90 to 1.13