### PR TITLE
Fix Fairmoney/NoIfInTestDescriptions cop when the description is nil

### DIFF
--- a/lib/rubocop/cop/fairmoney/no_if_in_test_descriptions.rb
+++ b/lib/rubocop/cop/fairmoney/no_if_in_test_descriptions.rb
@@ -20,7 +20,7 @@ module RuboCop
 
         def on_send(node)
           return unless %i[describe context it xit it_behaves_like].include?(node.method_name)
-          node.first_argument.each_node do |child_node|
+          node.first_argument&.each_node do |child_node|
             child_node.node_parts.each do |description_line|
               next unless description_line.class == String
               parse_description(child_node, description_line)

--- a/spec/rubocop/cop/fairmoney/no_if_in_test_descriptions_spec.rb
+++ b/spec/rubocop/cop/fairmoney/no_if_in_test_descriptions_spec.rb
@@ -20,4 +20,10 @@ RSpec.describe RuboCop::Cop::Fairmoney::NoIfInTestDescriptions do
       it 'does X when Y' do; end;
     RUBY
   end
+
+  it 'does not crash when there is no test description' do
+    expect_no_offenses(<<~RUBY)
+      it do; end;
+    RUBY
+  end
 end


### PR DESCRIPTION
Recently encountered a problem with `Fairmoney/NoIfInTestDescriptions` cop during one of my tests. It crashed by throwing 

```
NoMethodError: undefined method `each_node' for nil:NilClass
```

when an example didn't have a description just like this one: `it { is_expected.to be_empty }`